### PR TITLE
Add Replicate demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Cog Implementation of background_remover
 
+[![Try a demo on Replicate](https://replicate.com/codeplugtech/background_remover/badge)](https://replicate.com/codeplugtech/background_remover)
+
 `cog login `
 
 `cog push r8.im/codeplugtech/background_remover`


### PR DESCRIPTION
This PR adds a badge with a link to your model on Replicate, making it easier for users to try it out. 

Feel free to close if you don't want this, but many model creators have found it helpful.